### PR TITLE
Escape forward slash (#7695)

### DIFF
--- a/v1/lib/v1/searchable/query.rb
+++ b/v1/lib/v1/searchable/query.rb
@@ -11,7 +11,7 @@ module V1
 
       # not escaped, but probably could be if escape code was tweaked: '&&', '||'
       # not escaped, because they don't seem to need it: '+', '-',
-      ESCAPED_METACHARACTERS = [ '!', '(', ')', '{', '}', '[', ']', '^', '~', '?', ':' ]  # '"',
+      ESCAPED_METACHARACTERS = [ '!', '(', ')', '{', '}', '[', ']', '^', '~', '?', ':', '/' ]  # '"',
 
       def self.execute_empty_search(search)
         # We need to be explicit with an empty search

--- a/v1/spec/lib/v1/searchable/query_spec.rb
+++ b/v1/spec/lib/v1/searchable/query_spec.rb
@@ -217,8 +217,8 @@ module V1
         end
 
         it "escapes meta-characters just absolutely everywhere" do
-          string = '}?harv[a:z]('
-          expect(subject.protect_metacharacters(string)).to eq '\\}\\?harv\\[a\\:z\\]\\('
+          string = '}?harv[a:z](/'
+          expect(subject.protect_metacharacters(string)).to eq '\\}\\?harv\\[a\\:z\\]\\(\\/'
         end
       end
 


### PR DESCRIPTION
This fixes [#7695](https://issues.dp.la/issues/7695), which noted an error parsing "Yale University, Cushing/Whitney Medical Library".  As Mark M. discovered, when we upgraded to the newer version of Elasticsearch, we also started using a new version of Lucene, which uses `/` as a reserved character.  This code escapes `/`.

This also fixes the following cuke which was previously failing:

`cucumber features/metacharacter_filtering.feature:27 # Scenario: Basic keyword search with embedded double-quote`

There are other metacharacter cukes that are still failing (see [#7676](https://issues.dp.la/issues/7676)), but they are beyond the scope of this ticket.
