### PR TITLE
Fetch up to 50 items per call (7691)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Sorting by geo_distance requires a coordinate value in an additional sort_by_pin
 
 ### Retrieve multiple items by their 'id' values
 
+Up to 50 items can be fetched by their 'id' values per API call.
+
 <http://api.dp.la/v2/items/a4e2346032cae75b0832abe0644e9b26,a4e2346032cae75b0832abe064c14bcb> (comma separated IDs)
 
 ## Facets

--- a/features/uc008-item_detail.feature
+++ b/features/uc008-item_detail.feature
@@ -32,3 +32,6 @@ Feature: Retrieve detailed information about items (UC008)
     When I request details for items with ingestion identifiers "not_me,or_me"
     And items that identify errors with ids "not_me,or_me"
 
+  Scenario: Retrieve more than ten items with one call
+    When I request details for items with ingestion identifiers "aaa,bbb,1,2,3,P,P2,P3,P2-A,P2-B,C,D,F"
+    Then the API will return the items with the document identifiers "A,B,1,2,3,P,P2,P3,P2-A,P2-B,C,D,F"

--- a/v1/lib/v1/searchable.rb
+++ b/v1/lib/v1/searchable.rb
@@ -215,7 +215,8 @@ module V1
 
     def id_to_private_id(ids)
       #TODO: use a cacheable filter here instead?
-      search({'id' => ids.join(' OR ')})['docs'].inject({}) do |memo, doc|
+      search_params = {'id' => ids.join(' OR '), 'page_size' => 50}
+      search(search_params)['docs'].inject({}) do |memo, doc|
         memo[doc['id']] = doc['_id']
         memo
       end

--- a/v1/spec/lib/v1/searchable_spec.rb
+++ b/v1/spec/lib/v1/searchable_spec.rb
@@ -56,13 +56,13 @@ module V1
 
     describe "#id_to_private_id" do
       it "calls search correctly when called with a single id" do
-        subject.should_receive(:search).with({ 'id' => 'aaa' }) {
+        subject.should_receive(:search).with({ 'id' => 'aaa', 'page_size' => 50 }) {
           { 'docs' => [{"_id" => "A", "id" => "aaa"}] }
         }
         expect(subject.id_to_private_id(['aaa'])).to eq( {'aaa' => 'A'} )
       end
       it "calls search correctly when called with multiple ids" do
-        subject.should_receive(:search).with({ 'id' => 'aaa OR bbb' }) {
+        subject.should_receive(:search).with({ 'id' => 'aaa OR bbb', 'page_size' => 50 }) {
           { 'docs' => [{"_id" => "A", "id" => "aaa"}, {"_id" => "B", "id" => "bbb"}] }
         }
         expect(subject.id_to_private_id(['aaa', 'bbb'])).to eq( {'aaa' => 'A', 'bbb' => 'B'} )


### PR DESCRIPTION
This fixes [#7691](https://issues.dp.la/issues/7691).  This allows a call to the API to fetch items by id up to 50 at a time.  Before, you could only fetch 10 at a time.  
