### PR TITLE
Set field boosts to match PROD (fixes #7742)

### DIFF
--- a/v1/config/dpla.yml.example
+++ b/v1/config/dpla.yml.example
@@ -71,9 +71,8 @@ caching:
 field_boosts:
   item:
     sourceResource.title: 2
-    sourceResource.description: 1.5
-    sourceResource.subject: 0.8
+    sourceResource.description: 0.75
   collection:
-    title: 2.2
+    title: 1
 
         


### PR DESCRIPTION
A user reported that queries containing parentheses around boolean subqueries stopped working, such as `argonne AND ("world war, 1914-1918" OR "world war I" OR "great war")`. I noticed that there was a mismatch between the production configuration in the old Rackspace environment and what was in the platform repo (and, subsequently, what we deployed on AWS).

See also dpla/automation#35.
