### PR TITLE
UTF-8-encode input from log files in stats reporting

### DIFF
--- a/bin/get-api-stats.rb
+++ b/bin/get-api-stats.rb
@@ -64,13 +64,19 @@ def analyze_file(excluded_keys)
   puts "Omitting keys: #{skip_keys.keys}"
 
   # Rails log format
-  target_regexp = /^Started GET "([^"]+)" for .* at (\d{4}-\d{2}-\d{2})/
+  target_regexp = /^Started GET "([^"]+)" for .* at (\d{4}-\d{2}-\d{2})/u
   last_date = nil
   dates = {}
   keys = {}
   
   begin
     $stdin.each_line do |line|
+      # Converting the encoding to UTF-16 and then back to UTF-8 is necessary
+      # because the 'encode' method will not execute on a string if the string
+      # is detected to already be encoded in the specified encoding
+      line = line.force_encoding('UTF-8')
+        .encode('UTF-16', :invalid => :replace, :replace => '?')
+        .encode('UTF-8')
       next unless line =~ target_regexp
 
       url, date = $1, $2


### PR DESCRIPTION
This fixes issue [#7763](https://issues.dp.la/issues/7763)

`get-api-stats.rb` was throwing an ArgumentError at line 80 if the line being read in from the log file had a non-UTF-8 character.  This change encodes each log file line as UTF-8 before the regex evaluation.  It also ensures that the regex will use UTF-8 (line 67).
