### PR TITLE
Allow all origins for CORS

### DIFF
--- a/v1/app/controllers/v1/application_controller.rb
+++ b/v1/app/controllers/v1/application_controller.rb
@@ -44,6 +44,11 @@ module V1
       end
     end    
 
+    def render(*args)
+      response.headers['Access-Control-Allow-Origin'] = '*'
+      super
+    end
+
     def render_as_json(results, params)
       # Handles optional JSONP callback param
       conversion = results.is_a?(Hash) ? :to_json : :to_s


### PR DESCRIPTION
Add an "Access-Control-Allow-Origin: *" header for all responses, to
allow the API to be used by client-only Javascript applications,
allowing them to make cross-origin requests without having to use JSONP.
