### PR TITLE
Add parameter for exact matches of fields

### DIFF
--- a/v1/lib/v1/schema.rb
+++ b/v1/lib/v1/schema.rb
@@ -278,6 +278,17 @@ module V1
       ELASTICSEARCH_MAPPING
     end
 
+    ##
+    # Return a V1::Field corresponding to the given field name, or nil if the
+    # name does not correspond to a field.
+    #
+    # There are request parameters (e.g. "sort_by" or "callback") that are not
+    # field names. This method returns nil in those cases.
+    #
+    # @see V1::Searchable::Query.string_queries, where it evaluates whether
+    #      field.nil?
+    #
+    # @return [V1::Field] or [nil]
     def self.field(resource, name, modifier=nil)
       # A "resource" is a top-level DPLA resource: 'item', 'collection', 'creator'
       # TODO: memoize a hash value for every $name and return it if it exists. The modifier

--- a/v1/lib/v1/searchable.rb
+++ b/v1/lib/v1/searchable.rb
@@ -20,7 +20,9 @@ module V1
     MAX_PAGE_SIZE = 500
     
     # General query params that are not resource-specific
-    BASE_QUERY_PARAMS = %w( q controller action sort_by sort_by_pin sort_order page page_size facets facet_size filter_facets fields callback _ x ).freeze
+    BASE_QUERY_PARAMS = %w( q controller action sort_by sort_by_pin sort_order
+                            page page_size facets facet_size filter_facets
+                            fields callback _ x exact_field_match ).freeze
 
     def resource
       raise "Modules extending Searchable must define resource() method"

--- a/v1/spec/lib/v1/searchable_spec.rb
+++ b/v1/spec/lib/v1/searchable_spec.rb
@@ -26,7 +26,9 @@ module V1
 
         it "BASE_QUERY_PARAMS has the correct value" do
           expect(BASE_QUERY_PARAMS).to match_array %w( 
-              q controller action sort_by sort_by_pin sort_order page page_size facets facet_size filter_facets fields callback _ x
+              q controller action sort_by sort_by_pin sort_order page page_size
+              facets facet_size filter_facets fields callback _ x
+              exact_field_match
             )
         end
 


### PR DESCRIPTION
Fixes https://issues.dp.la/issues/8398 ("Faceting is inaccurate").

Adds a querystring parameter to the API named `exact_field_match`, which disables tokenized searching on fields given in the `fields' parameter. These fields are used in applications like the DPLA frontend where the user follows links based on facet values from previous searches.  A tokenized search -- for example, where the phrase "University of Pennsylvania" is broken down and the terms "University" and "Pennsylvania" are considered indepenedently -- is not wanted in this case, where we need an exact filter placed on "University of Pennsylvania".

This also adds a number of doc comments that I added while I was trying to understand the existing code.
