### PR TITLE
Create Elasticsearch River with last sequence param

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,19 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
+require 'stringio'
+
+##
+# Helper for evaluating stdout from puts statements for rspec < 3.0
+def capture_stdout(&blk)
+  old = $stdout
+  $stdout = fake = StringIO.new
+  blk.call
+  fake.string
+ensure
+  $stdout = old
+end
+
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.

--- a/v1/lib/tasks/dpla.rake
+++ b/v1/lib/tasks/dpla.rake
@@ -54,14 +54,19 @@ namespace :v1 do
     V1::SearchEngine::River.recreate_river
   end
 
-  desc "Creates new ElasticSearch river, pointed at $index (defaults to currently deployed index)"
-  task :create_river, [:index,:river] => :environment do |t, args|
-    V1::SearchEngine::River.create_river('index' => args.index, 'river' => args.river)
+  desc "Creates new ElasticSearch river"
+  task :create_river, [:index, :river, :last_seq] => :environment do |t, args|
+    V1::SearchEngine::River.create_river(
+      'index' => args.index,
+      'river' => args.river,
+      'last_seq' => args.last_seq
+    )
   end
 
-  desc "Deletes ElasticSearch river named '#{V1::Config.river_name}'"
-  task :delete_river do
-    V1::SearchEngine::River.delete_river or puts "River does not exist, so nothing to delete"
+  desc "Deletes ElasticSearch river"
+  task :delete_river, [:river] => :environment do |t, args|
+    V1::SearchEngine::River.delete_river(args.river) \
+      or puts "River does not exist, so nothing to delete"
   end
 
   desc "Displays the river's current indexing velocity"

--- a/v1/lib/v1/search_engine.rb
+++ b/v1/lib/v1/search_engine.rb
@@ -72,7 +72,7 @@ module V1
     def self.recreate_env!
       recreate_index!
       import_test_dataset
-      create_river
+      create_river("0")
       puts "ElasticSearch docs: #{ doc_count }"
     end
 
@@ -148,7 +148,7 @@ module V1
       endpoint_config_check
 
       name = create_index
-      River.create_river('index' => name, 'river' => name)
+      River.create_river('index' => name, 'river' => name, 'last_seq' => "0")
       name
     end
     
@@ -245,7 +245,7 @@ module V1
       delete_river(index)
       delete_river
       previous_index = move_alias_to(index)
-      create_river
+      create_river("0")
       puts "Index '#{index}' deployed OK."
 
       if previous_index && previous_index != index
@@ -294,13 +294,16 @@ module V1
       alias_object ? alias_object.index.first : nil
     end
 
+    ##
+    # Is only called by V1::Repository.recreate_env, which is only supposed to
+    # run in development.
     def self.recreate_river
       delete_river
-      create_river
+      create_river("0")
     end
 
-    def self.create_river
-      River.create_river
+    def self.create_river(last_seq)
+      River.create_river({'last_seq' => last_seq})
     end
 
     def self.delete_river(*args)

--- a/v1/lib/v1/search_engine/river.rb
+++ b/v1/lib/v1/search_engine/river.rb
@@ -9,9 +9,22 @@ module V1
 
     module River
 
-      def self.recreate_river
+      ##
+      # Recreate an existing River.
+      #
+      # The river must exist. If it does not exist, an exception will be
+      # passed from `.last_sequence'. If you want a new river, use
+      # `.create_river'!
+      #
+      # @raise [RuntimeError]   Pass exceptions from `.last_sequence'
+      # @see self.last_sequence
+      #
+      def self.recreate_river(last_seq=nil)
+        puts "Recreating river"
+        last_seq ||= last_sequence  # exception if it doesn't exist.
+        puts "Using last sequence #{last_seq}"
         delete_river
-        create_river
+        create_river({'last_seq' => last_seq})
       end
 
       def self.delete_river(name=river_name)
@@ -57,16 +70,25 @@ module V1
         # defaults are the active index and river
         river = options['river'] || Config.river_name
         index = options['index'] || SearchEngine.alias_to_index(Config.search_index)
+        last_seq = options['last_seq'] || nil
 
-        # this fails if the index has not been deployed
+        raise "Last sequence number not specified (use \"0\" if new)" \
+          if last_seq.nil?
         
-        raise "Cannot create river for an index that does not exist" if index.nil?
+        raise "Cannot create river for an index that does not exist" \
+          if index.nil?
         validate_river_params_for(index)
+
+        puts "Creating river #{river} for index #{index} with last sequence " \
+             "#{last_seq}"
+
+        last_sequence!(last_seq, river_name)
 
         #TODO: refuse to create a river that already exists #HTTParty.head ...
         repository = Repository.reader_cluster_database.to_s
         river_payload = river_creation_doc(index, repository).to_json
 
+        # Creation fails if the index has not been deployed
         # :body key must be a symbol
         result = HTTParty.put(
                               "#{endpoint(river)}/_meta",
@@ -165,27 +187,85 @@ module V1
           error = source['error']
           raise "Problem with river on node '#{node}': #{error}"
         else
-          if last_sequence.nil?
-            return "River exists but is not flowing (last_seq is nil)"
-          else
-            index = service_meta(name)['_source']['index']['index']
-            return "River '#{name}' pointed at index '#{index}' running on node '#{node}'"
-          end
+          index = service_meta(name)['_source']['index']['index']
+          last_seq = last_sequence(name)
+          return "River '#{name}' pointed at index '#{index}' last sequence " \
+                 "#{last_seq} running on node '#{node}'"
         end
       end
 
+      ##
+      # Get the last sequence number from the River
+      #
+      # This method used to return nil if HTTParty.get failed. There were no
+      # unit tests, so we have to determine the correct behavior through
+      # analysis. `.recreate_river' above is now stricter about only
+      # _re_creating rivers, so maybe this function used to ignore errors
+      # because it was convenient to create a new river if one didn't exist.
+      #
+      # An exception will be raised if the River exists, but never started
+      # flowing because the source CouchDB database is still empty.  In that
+      # case, the HTTP GET request to the River endpoint will return HTTP
+      # status 404 and the response body will be a JSON object without
+      # the '_source' property. The remedy to this is to require a last
+      # sequence number when creating a River, which we now do, to eliminate
+      # ambiguity.  A last_seq property of "0" can be specified in that case.
+      #
+      # When queried for the last sequence (/_river/rivername/_seq), the
+      # River returns the 'last_seq' property from CouchDB's /db/_changes
+      # endpoint, OR the sequence number entered upon River creation, if the
+      # River has not processed any documents from CouchDB yet.  Therefore,
+      # for the sequence number we get a JSON-encoded array (that comes from
+      # CouchDB[1], if the River has been flowing) or otherwise get the
+      # straight value that had earlier been PUT to `_seq'.  Further note
+      # that, based on our experimentation, you can PUT `_seq' as an integer
+      # or string[2], and `_seq' will return either integer or string.
+      #
+      # [1] {"results": [...], "last_seq":[241608,"g1AAAAFveJzL..."]}, which
+      #     is then JSON-encoded when the River returns it to you.
+      # [2] https://github.com/elastic/elasticsearch-river-couchdb/tree/v1.3.0#starting-at-a-specific-sequence
+      # -mb
+      #
+      # @return [String or Fixnum]  Last sequence value
+      # @param  name [String]       Name of the River
+      # @raise  [RuntimeError] if the HTTP request to the River endpoint fails
+      # @see self.recreate_river
+      #
       def self.last_sequence(name=river_name)
         # name will be present but nil when called from a rake task
         name ||= river_name
-        response = HTTParty.get(endpoint(name) + '/_seq').parsed_response
-        seq = response['_source']['couchdb']['last_seq'] rescue nil
+        response = HTTParty.get(endpoint(name) + '/_seq')
+        raise "Problem getting last sequence: #{JSON.parse(response.body)}" \
+          unless response.success?
+        response.parsed_response['_source']['couchdb']['last_seq']
+      end
 
-        return nil if seq.nil?
-
-        # handle bigcouch's last_seq format if it looks like it
+      def self.last_sequence_number(name=river_name)
+        seq = last_sequence(name).to_s  # it's usually string
         seq = JSON.parse(seq).first if seq !~ /^\d+$/
-
         seq.to_i
+      end
+
+      ##
+      # Set the last sequence number for a River.
+      #
+      # The sequence number can be PUT for a River before the rest of it is
+      # created by a PUT to its _meta resource. Putting last_seq creates a data
+      # structure for the incomplete river. When you do this (before PUTing to
+      # `_meta') you'll see a property for the new river in `/_river/_mapping'.
+      #
+      # @param  last_seq [Fixnum or String] Sequence number /^\d+$/
+      # @return true
+      # @raise [RuntimeError]  if HTTP transaction fails
+      #
+      def self.last_sequence!(last_seq, rname=river_name)
+        # rname will be present but nil when called from a rake task
+        rname ||= river_name
+        body = {couchdb: {last_seq: last_seq}}.to_json
+        res = HTTParty.put(endpoint(rname) + '/_seq', body: body)
+        raise "Problem setting river sequence: #{JSON.parse(res.body)}" \
+          unless res.success?
+        true
       end
 
       def self.current_velocity(name=river_name)
@@ -194,12 +274,12 @@ module V1
         name ||= river_name
         sleep_time = 3
 
-        start_seq = last_sequence(name)
+        start_seq = last_sequence_number(name)
         if start_seq.nil?
           raise "Can't get velocity for river '#{name}'. It looks broken. (last_seq is nil)"
         end
         sleep sleep_time
-        end_seq = last_sequence(name)
+        end_seq = last_sequence_number(name)
 
         velocity = (end_seq.to_f - start_seq.to_f) / sleep_time
         "#{ sprintf("%.1f", velocity) } docs/sec"

--- a/v1/spec/lib/v1/search_engine/river_spec.rb
+++ b/v1/spec/lib/v1/search_engine/river_spec.rb
@@ -1,4 +1,5 @@
 require 'v1/search_engine/river'
+require 'spec_helper'
 
 module V1
 
@@ -8,45 +9,234 @@ module V1
 
       describe River do
 
+        before(:each) do
+            Config.stub(:search_endpoint) { 'server:9200' }
+            subject.stub(:river_name) { 'danube' }          
+        end
+
         describe "#endpoint" do
           it "returns correct value" do
-            Config.stub(:search_endpoint) { 'server:9200' }
-            subject.stub(:river_name) { 'danube' }
             expect(subject.endpoint).to eq 'server:9200/_river/danube'
           end
         end
 
         describe "#river_creation_doc" do
           it "returns the correct content" do
-          database_uri = 'http://user1:pass1@host:5984/db1'
-          expect(subject.river_creation_doc('index1', database_uri))
-            .to eq(
-                   {
-                     'type' => 'couchdb',
-                     'couchdb' => {
-                       'host' => 'host',
-                       'port' => 5984,
-                       'db' => 'db1',
-                       'user' => 'user1',
-                       'password' => 'pass1',
-                       'bulk_size' => '500',
-                       'bulk_timeout' => '3s',
-                       'script' => subject.river_script
-                     },
-                     'index' => {
-                       'index' => 'index1'
+            database_uri = 'http://user1:pass1@host:5984/db1'
+            expect(subject.river_creation_doc('index1', database_uri))
+              .to eq(
+                     {
+                       'type' => 'couchdb',
+                       'couchdb' => {
+                         'host' => 'host',
+                         'port' => 5984,
+                         'db' => 'db1',
+                         'user' => 'user1',
+                         'password' => 'pass1',
+                         'bulk_size' => '500',
+                         'bulk_timeout' => '3s',
+                         'script' => subject.river_script
+                       },
+                       'index' => {
+                         'index' => 'index1'
+                       }
                      }
-                   }
-                   )
+                     )
           end
-
         end
 
+        context "with HTTP transactions" do
+          let(:resp) { double }
+          let(:error_body) { '{"error": "fooey"}' }
+
+          describe ".last_sequence" do
+            before do
+                allow(HTTParty).to receive(:get)
+                  .with('server:9200/_river/danube/_seq')
+                  .and_return(resp)
+            end
+
+            context "with successful HTTP response" do
+              let(:parsed_resp) {
+                {
+                  '_source' => {
+                    'couchdb' => {
+                      'last_seq' => "1"
+                    }                  
+                  }
+                }
+              }
+              before do
+                allow(resp).to receive(:parsed_response)
+                  .and_return(parsed_resp)
+                allow(resp).to receive(:success?).and_return(true)
+              end
+
+              it "returns the correct last_seq from response" do
+                expect(subject.last_sequence).to eq("1")
+              end
+            end
+
+            context "with unsuccessful HTTP response" do
+              before do
+                allow(resp).to receive(:success?).and_return(false)
+                allow(resp).to receive(:body).and_return(error_body)
+              end
+
+              it "raises an exception" do
+                expect {subject.last_sequence}
+                  .to raise_error(RuntimeError,
+                                  /^Problem getting last sequence/)
+              end
+            end
+          end
+
+          describe ".last_sequence!" do
+            let(:putdata) {
+              {couchdb: {last_seq: "1"}}
+            }
+            before do
+            end
+
+            context "with successful HTTP response" do
+              before do
+                allow(resp).to receive(:success?).and_return(true)
+              end
+
+              it "makes a PUT request with the right properties" do
+                ["1", "2"].each do |n|
+                  putdata[:couchdb][:last_seq] = n
+                  expect(HTTParty).to receive(:put)
+                    .with('server:9200/_river/danube/_seq',
+                          {body: putdata.to_json})
+                    .and_return(resp)
+                  subject.last_sequence!(n)
+                end
+              end
+            end
+
+            context "with unsuccessful HTTP response" do
+              before do
+                allow(resp).to receive(:success?).and_return(false)
+                allow(resp).to receive(:body).and_return(error_body)
+                allow(HTTParty).to receive(:put).and_return(resp)
+              end
+
+              it "raises an exception" do
+                expect {subject.last_sequence!(0)}
+                  .to raise_error(RuntimeError,
+                                  /^Problem setting river sequence/)
+              end
+            end
+          end  # .last_sequence!
+
+          describe ".last_sequence_number" do
+            it "returns the correct integer when the sequence is a " \
+               "JSON-encoded array from CouchDB's _changes endpoint" do
+              allow(subject)
+                .to receive(:last_sequence)
+                .and_return("[3253021,\"g1AAAAFzeJzLYWBg4MhgTmEQSspM...\"]")
+              expect(subject.last_sequence_number).to eq(3253021)
+            end
+
+            it "returns correct integer when sequence is numeric string" do
+              allow(subject)
+                .to receive(:last_sequence)
+                .and_return("123")
+              expect(subject.last_sequence_number).to eq(123)
+            end
+
+            it "returns correct integer when sequence is an integer" do
+              allow(subject)
+                .to receive(:last_sequence)
+                .and_return(123)
+              expect(subject.last_sequence_number).to eq(123)
+            end
+
+          end
+
+          describe ".create_river" do
+            let(:opts) {
+              {
+                'river' => 'the_river',
+                'index' => 'the_index',
+                'last_seq' => '0'
+              }
+            }
+
+            it "raises an exception if last sequence number is not given" do
+              opts.delete('last_seq')
+              expect {subject.create_river(opts)}
+                .to raise_error(RuntimeError,
+                                /^Last sequence number not specified/)
+            end
+
+            it "raises an exception if index does not exist" do
+              opts.delete('index')
+              allow(V1::SearchEngine)
+                .to receive(:alias_to_index).and_return(nil)
+              allow(V1::SearchEngine).to receive(:find_alias).and_return(false)
+              allow(HTTParty).to receive(:put).and_return(resp)
+              expect {subject.create_river(opts)}
+                .to raise_error(RuntimeError,
+                                /^Cannot create river/)
+            end
+
+            it "sets the last sequence for the river it will create" do
+              allow(V1::SearchEngine)
+                .to receive(:alias_to_index).and_return('dpla-123')
+              allow(V1::SearchEngine).to receive(:find_alias).and_return(false)
+              allow(HTTParty).to receive(:put).and_return(resp)
+              allow(resp).to receive(:success?).and_return(true)
+              allow(subject).to receive(:verify_river_status).and_return('')
+              expect(subject).to receive(:last_sequence!)
+                .with("0", "danube").and_return(true)
+              subject.create_river(opts)
+            end
+          end
+
+          describe ".recreate_river" do
+            before do
+              allow(subject).to receive(:last_sequence).and_return(1)
+              allow(subject).to receive(:delete_river).and_return(nil)
+              allow(subject).to receive(:create_river).and_return(nil)
+            end
+
+            it "looks up the river's last sequence if it's not given" do
+              expect(subject).to receive(:last_sequence).and_return(1)
+              subject.recreate_river  # no sequence arg
+            end
+
+            it "uses the last sequence argument if it's given" do
+              expect(subject)
+                .to receive(:create_river).with({'last_seq' => "2"})
+              subject.recreate_river("2")
+            end
+
+            it "reports last sequence number of old river to stdout" do
+              printed = capture_stdout do
+                subject.recreate_river
+              end
+              expect(printed).to match(/Using last sequence 1/)
+            end
+
+            it "deletes the default river" do
+              expect(subject).to receive(:delete_river).with().and_return(nil)
+              subject.recreate_river
+            end
+
+            it "creates a new river with the old one's last sequence and " \
+               "other options at their defaults" do
+              last = subject.last_sequence
+              expect(subject)
+                .to receive(:create_river).with({'last_seq' => last})
+                .and_return(nil)
+              subject.recreate_river
+            end
+          end
+        end  # with HTTP responses
+
       end
-
     end
-
   end
-
 end
-


### PR DESCRIPTION
- Change River creation to require a last sequence number parameter, and to set it on the newly-created River.
- Leave `V1::SearchEngine` shims for methods in `V1::SearchEngine::River` in-place but modified them where necessary, related to the River creation change.
- Update River re-creation to get the last sequence number of the old River and set it for the new one.
- Alter the behavior of `V1::SearchEngine::River.last_sequence` for it to raise an exception if there is an HTTP error, such as will happen if the river does not exists, or exists, but it pointed at an empty CouchDB database without having a `last_seq` number set. This should be an edge case now that we're having create_river require a `last_seq` parameter.
- Add a number of missing unit tests for `V1::SearchEngine::River`.
- Add status messages to stdout.
- Add doc comments.

Rake task changes:
- `create_river`: Task description no longer suggests defaulting to the currently-deployed index (implies that you should specify it). I'm not sure anyway that you could have left it empty in the rake task arguments.
- `delete_river`: Now requires that you enter the name of the river to delete.

Addresses https://issues.dp.la/issues/8576 