### PR TITLE
Revise default argument assignments, river.rb

### DIFF
--- a/v1/lib/v1/search_engine/river.rb
+++ b/v1/lib/v1/search_engine/river.rb
@@ -172,7 +172,7 @@ module V1
         Config.search_endpoint + '/_river/' + name
       end
 
-      def self.verify_river_status(name=river_name)
+      def self.verify_river_status(name=nil)
         # Verify that the river was actually created successfully. ElasticSearch's initial
         # response in $create_result won't report if there was a deeper problem with the
         # river we tried to create.
@@ -231,7 +231,7 @@ module V1
       # @raise  [RuntimeError] if the HTTP request to the River endpoint fails
       # @see self.recreate_river
       #
-      def self.last_sequence(name=river_name)
+      def self.last_sequence(name=nil)
         # name will be present but nil when called from a rake task
         name ||= river_name
         response = HTTParty.get(endpoint(name) + '/_seq')
@@ -258,7 +258,7 @@ module V1
       # @return true
       # @raise [RuntimeError]  if HTTP transaction fails
       #
-      def self.last_sequence!(last_seq, rname=river_name)
+      def self.last_sequence!(last_seq, rname=nil)
         # rname will be present but nil when called from a rake task
         rname ||= river_name
         body = {couchdb: {last_seq: last_seq}}.to_json
@@ -268,7 +268,7 @@ module V1
         true
       end
 
-      def self.current_velocity(name=river_name)
+      def self.current_velocity(name=nil)
         # Sadly, a delta of 10 does not guarantee 10 docs have been processed, but this
         # is still a relatively useful metric. Zero velocity means "no activity at all."
         name ||= river_name


### PR DESCRIPTION
This is just to fix a minor nitpick that I had with some of the method arguments in `river.rb`.

Revise default argument assignments in V1::SearchEngine::River where the idea is to handle a `nil` value that's passed from a rake task.  If there's going to be an assignment with `||=` at the top of the method, then it's just neater to use `arg=nil` in the method arguments. Otherwise, there's a momentary cognitive disconnect seeing an assignment like `name = river_name` done twice in a row.