### PR TITLE
Pin public_suffix gem in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'devise', '~> 2.1.2'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'dpla_search_api_v1', :path => 'v1'
+gem 'public_suffix', '~> 1.4.0'
 
 # twitter-bootstrap-rails can have problems finding itself when it is in the assets group
 gem 'twitter-bootstrap-rails', '~> 2.2.8'


### PR DESCRIPTION
This gem has mysteriously started being included (by one of our dependencies, presumably) and `gem dep -R` does not reveal what is including it. The public_suffix gem has apparently hit version 2, which is incompatible with Ruby 1.9, so we get errors when it's not pinned to 1.4.x.