### PR TITLE
Change es search type

### DIFF
--- a/v1/lib/v1/searchable.rb
+++ b/v1/lib/v1/searchable.rb
@@ -47,7 +47,8 @@ module V1
       validate_query_params(params)
       validate_field_params(params)
 
-      search = Tire.search(Config.search_index + '/' + resource) do |search|
+      search = Tire.search(Config.search_index + '/' + resource,
+                           search_type: 'dfs_query_then_fetch') do |search|
         global_facets = nil
 
         search.query do |query|

--- a/v1/lib/v1/searchable/sort.rb
+++ b/v1/lib/v1/searchable/sort.rb
@@ -60,7 +60,14 @@ module V1
           end
           
           # Default
-          return { '_score' => { 'order' => 'desc' } }
+          return {
+            '_score' => {
+              'order' => 'desc'
+            },
+            '_id' => {
+              'order' => 'asc'
+            }
+          }
         end
 
         sort_field = sort_by(resource, sort_by_name)

--- a/v1/spec/lib/v1/searchable/sort_spec.rb
+++ b/v1/spec/lib/v1/searchable/sort_spec.rb
@@ -102,7 +102,10 @@ module V1
           params = {}
           expect(
                  subject.build_sort_attributes(resource, params)
-                 ).to eq({ '_score' => {'order' => 'desc'} })
+                 ).to eq({
+                  '_score' => {'order' => 'desc'},
+                  '_id' => {'order' => 'asc'}
+                 })
         end
 
         it "uses default sort_order if no sort_order param present" do

--- a/v1/spec/lib/v1/searchable_spec.rb
+++ b/v1/spec/lib/v1/searchable_spec.rb
@@ -451,7 +451,10 @@ module V1
 
       it "restricts all searches to a resource" do
         params = {'q' => 'banana'}
-        Tire.should_receive(:search).with(Config.search_index + '/' + resource)
+        Tire.should_receive(:search).with(
+          Config.search_index + '/' + resource,
+          {search_type: 'dfs_query_then_fetch'}
+        )
         subject.search(params)
       end
 


### PR DESCRIPTION
Change the `search_type` parameter that's used for Elasticsearch searches to solve the ordering problem that's described in https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1921

This article describes the gist of the issue and the parameter that's been added: https://www.elastic.co/blog/understanding-query-then-fetch-vs-dfs-query-then-fetch

In addition to specifying `dfs_query_then_fetch`, we've found that we need to augment the search-ordering clause to include the item ID in addition to its relevancy score, as a tiebreaker, so that we can guarantee the same ordering every time.
