### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'sqlite3', '~> 1.3.0'
 gem 'devise', '~> 2.1.2'
 gem 'dpla_search_api_v1', :path => 'v1'
 gem 'public_suffix', '~> 1.4.0'
+gem 'httparty', '~> 0.14.0'
 
 # twitter-bootstrap-rails can have problems finding itself when it is in the assets group
 gem 'twitter-bootstrap-rails', '~> 2.2.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: v1
   specs:
-    dpla_search_api_v1 (3.2.1)
+    dpla_search_api_v1 (3.2.2)
       couchrest (= 1.1.3)
       dalli
       httparty
@@ -242,6 +242,7 @@ DEPENDENCIES
   database_cleaner (~> 1.5.0)
   devise (~> 2.1.2)
   dpla_search_api_v1!
+  httparty (~> 0.14.0)
   less-rails (~> 2.6.0)
   pg (~> 0.17.1)
   pry
@@ -261,4 +262,4 @@ DEPENDENCIES
   unicorn (~> 4.8.3)
 
 BUNDLED WITH
-   1.13.6
+   1.16.0


### PR DESCRIPTION
Update the `httparty` Gemfile entry so that bundler doesn't try to pull version 0.15, which is incompatible with Ruby 1.9.

The dpla_search_api_v1 entry in Gemfile.lock is automatically updated. We're supposed to run `bundle install` as part of the release process, which will update Gemfile.lock with each release. This wasn't done last time.
