### PR TITLE
Google analytics

### DIFF
--- a/v1/app/controllers/v1/search_controller.rb
+++ b/v1/app/controllers/v1/search_controller.rb
@@ -52,7 +52,6 @@ module V1
         results = e
       end
       Thread.new do
-        sleep(20)
         GoogleAnalytics.track_items(request, results, "Item search results")
       end
       render_search_results(results, params)
@@ -72,7 +71,6 @@ module V1
           Item.fetch(params[:ids].split(/,\s*/)).to_json
         end
         Thread.new do
-          sleep(20)
           GoogleAnalytics.track_items(request, results, "Fetch items")
         end
         render :json => render_as_json(results, params)

--- a/v1/app/controllers/v1/search_controller.rb
+++ b/v1/app/controllers/v1/search_controller.rb
@@ -53,6 +53,7 @@ module V1
       end
       Thread.new do
         GoogleAnalytics.track_items(request, results, "Item search results")
+        sleep(20)
       end
       render_search_results(results, params)
     end
@@ -72,6 +73,7 @@ module V1
         end
         Thread.new do
           GoogleAnalytics.track_items(request, results, "Fetch items")
+          sleep(20)
         end
         render :json => render_as_json(results, params)
       rescue NotFoundSearchError => e

--- a/v1/app/controllers/v1/search_controller.rb
+++ b/v1/app/controllers/v1/search_controller.rb
@@ -1,4 +1,5 @@
 require 'v1/results_cache'
+require 'v1/google_analytics'
 
 #TODO: eliminate new duplication between resources here and break this into ItemsController and CollectionsController (to invert the current topology)
 #TODO: Consider handling all our own exception classes in a: rescue_from SearchError
@@ -46,11 +47,11 @@ module V1
             e
           end
         end
-        # render :json => render_as_json(results, params)
       rescue SearchError => e
         # render_error(e, params)
         results = e
       end
+      GoogleAnalytics.track_items(request, results, "Item search results")
       render_search_results(results, params)
     end
 
@@ -67,6 +68,7 @@ module V1
         results = Rails.cache.fetch(fetch_cache_key('items', params), :raw => true) do
           Item.fetch(params[:ids].split(/,\s*/)).to_json
         end
+        GoogleAnalytics.track_items(request, results, "Fetch items")
         render :json => render_as_json(results, params)
       rescue NotFoundSearchError => e
         render_error(e, params)

--- a/v1/app/controllers/v1/search_controller.rb
+++ b/v1/app/controllers/v1/search_controller.rb
@@ -51,8 +51,13 @@ module V1
         # render_error(e, params)
         results = e
       end
+      # Clone for extra thread safety
+      results_clone = results.clone
+      request_clone = request.clone
       Thread.new do
-        GoogleAnalytics.track_items(request, results, "Item search results")
+        GoogleAnalytics.track_items(request_clone,
+                                    results_clone,
+                                    "Item search results")
       end
       render_search_results(results, params)
     end
@@ -70,8 +75,13 @@ module V1
         results = Rails.cache.fetch(fetch_cache_key('items', params), :raw => true) do
           Item.fetch(params[:ids].split(/,\s*/)).to_json
         end
+        # Clone for extra thread safety
+        results_clone = results.clone
+        request_clone = request.clone
         Thread.new do
-          GoogleAnalytics.track_items(request, results, "Fetch items")
+          GoogleAnalytics.track_items(request_clone,
+                                      results_clone,
+                                      "Fetch items")
         end
         render :json => render_as_json(results, params)
       rescue NotFoundSearchError => e

--- a/v1/app/controllers/v1/search_controller.rb
+++ b/v1/app/controllers/v1/search_controller.rb
@@ -52,8 +52,8 @@ module V1
         results = e
       end
       Thread.new do
-        GoogleAnalytics.track_items(request, results, "Item search results")
         sleep(20)
+        GoogleAnalytics.track_items(request, results, "Item search results")
       end
       render_search_results(results, params)
     end
@@ -72,8 +72,8 @@ module V1
           Item.fetch(params[:ids].split(/,\s*/)).to_json
         end
         Thread.new do
-          GoogleAnalytics.track_items(request, results, "Fetch items")
           sleep(20)
+          GoogleAnalytics.track_items(request, results, "Fetch items")
         end
         render :json => render_as_json(results, params)
       rescue NotFoundSearchError => e

--- a/v1/app/controllers/v1/search_controller.rb
+++ b/v1/app/controllers/v1/search_controller.rb
@@ -51,7 +51,9 @@ module V1
         # render_error(e, params)
         results = e
       end
-      GoogleAnalytics.track_items(request, results, "Item search results")
+      Thread.new do
+        GoogleAnalytics.track_items(request, results, "Item search results")
+      end
       render_search_results(results, params)
     end
 
@@ -68,7 +70,9 @@ module V1
         results = Rails.cache.fetch(fetch_cache_key('items', params), :raw => true) do
           Item.fetch(params[:ids].split(/,\s*/)).to_json
         end
-        GoogleAnalytics.track_items(request, results, "Fetch items")
+        Thread.new do
+          GoogleAnalytics.track_items(request, results, "Fetch items")
+        end
         render :json => render_as_json(results, params)
       rescue NotFoundSearchError => e
         render_error(e, params)

--- a/v1/config/dpla.yml.example
+++ b/v1/config/dpla.yml.example
@@ -75,4 +75,7 @@ field_boosts:
   collection:
     title: 1
 
+google_analytics:
+  tid: UA-XXXX-Y
+
         

--- a/v1/lib/v1/config.rb
+++ b/v1/lib/v1/config.rb
@@ -82,6 +82,10 @@ module V1
       
       store
     end
+
+    def self.google_analytics_tid
+      dpla['google_analytics']['tid'] rescue nil
+    end
     
   end
 

--- a/v1/lib/v1/google_analytics.rb
+++ b/v1/lib/v1/google_analytics.rb
@@ -1,0 +1,143 @@
+##
+# Post usage measurements to Google Analytics using the Measurement Protocol.
+# @see https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide
+#
+# Errors may be logged, but should be invisible to the end user.
+
+require 'httparty'
+
+module V1
+  class GoogleAnalytics
+    include HTTParty
+
+    ##
+    # @param request ActionDispatch::Request
+    # @param results JSON
+    # @param page_title String
+    def self.track_items(request, results, page_title)
+      return if results.is_a? SearchError
+      begin
+        parsed_results = JSON.parse(results)
+        self.track_pageview(request, page_title)
+        self.track_events(request, parsed_results, page_title, "View API Item")
+      rescue Exception => e
+        # Fail silently if there are any unexpected errors.
+        Rails.logger.error("Attempt at Google Analytics tracking failed with "\
+          "the following message: #{e.message}")
+      end
+    end
+
+    ##
+    # @param request ActionDispatch::Request
+    # @param page_title String
+    def self.track_pageview(request, page_title)
+      data = { t: "pageview" }
+      data[:dh] = request.host
+      data[:dp] = request.fullpath # Includes request params
+      data[:dt] = page_title
+      data[:cid] = request.query_parameters[:api_key]
+
+      path = self.single_path
+      body = self.data_string(data)
+      self.post_request(path, body)
+    end
+
+    ##
+    # @param request ActionDispatch::Request
+    # @param results Hash
+    # @param page_title String
+    # @param event String
+    def self.track_events(request, results, page_title, event)
+      path = self.batch_path
+      body = self.event_data(request, results, page_title, event)
+      self.post_request(path, body)
+    end
+
+    private
+
+    ##
+    # Google analytics POST path for a single measurement.
+    def self.single_path
+      "http://www.google-analytics.com/collect"
+    end
+
+    ##
+    # Google analytics POST path for a batch (multiple measurements).
+    def self.batch_path
+      "http://www.google-analytics.com/batch"
+    end
+
+
+    ##
+    # Make HTTP POST request
+    #
+    # @param path String
+    # @param body String
+    #
+    def self.post_request(path, body)
+      begin
+        response = HTTParty.post(path, { body: body  })
+        # TODO: Is this the correct data to add to the log? May be too verbose.
+        Rails.logger.info("Google Analytics POST: #{response.request.uri} "\
+          "#{response.request.raw_body}")
+        Rails.logger.info("Google Analytics RESPONSE CODE: #{response.code}")
+      rescue Exception => e
+        Rails.logger.error("Google Analytics POST attempt failed with the "\
+          "following message: #{e.message}")
+      end
+    end
+
+    ##
+    # Create a string of data to be used in a request body.
+    # @param data Hash - keys and values specific to a single pageview, event, etc.
+    # @return String
+    def self.data_string(data)
+      # Add required fields.
+      data[:v] = "1"
+      data[:tid] = Config.google_analytics_tid
+
+      data.map{ |k, v| "#{k}=#{v}" }.join("&")
+    end
+
+    ##
+    # @param results Hash
+    # @param event String
+    #
+    # Create a single string of event data to be used in a request body.
+    # There may be 0 to many events represented the return string,
+    # corresponding to the number of docs in the results.
+    # Each individual event is represented on its own line, as required by
+    # the Measurement Protocol.
+    def self.event_data(request, results, page_title, event)
+      begin
+        data_strings = results['docs'].map do |doc|
+          provider = self.join_if_array(doc['provider']['name']) rescue ""
+          data_provider = self.join_if_array(doc['dataProvider']) rescue ""
+          id = self.join_if_array(doc['id']) rescue ""
+          title = self.join_if_array(doc['sourceResource']['title']) rescue ""
+
+          data = { t: "event" }
+          data[:ec] = "#{event} : #{provider}"
+          data[:ea] = data_provider
+          data[:el] = "#{id} : #{title}"
+          data[:dh] = request.host
+          data[:dp] = request.fullpath # Includes request params
+          data[:dt] = page_title
+          data[:cid] = request.query_parameters[:api_key]
+
+          self.data_string(data)
+        end
+        data_strings.join("\n")
+      rescue
+        # Fail silently if unable to parse results
+      end
+    end
+
+    ##
+    # @param String | Array
+    # @return String
+    def self.join_if_array(value)
+      Array.wrap(value).join(", ")
+    end
+  end
+end

--- a/v1/lib/v1/google_analytics.rb
+++ b/v1/lib/v1/google_analytics.rb
@@ -22,7 +22,7 @@ module V1
         self.track_events(request, parsed_results, page_title, "View API Item")
       rescue Exception => e
         # Fail silently if there are any unexpected errors.
-        Rails.logger.error("Attempt at Google Analytics tracking failed with "\
+        Rails.logger.debug("Attempt at Google Analytics tracking failed with "\
           "the following message: #{e.message}")
       end
     end
@@ -78,11 +78,11 @@ module V1
       begin
         response = HTTParty.post(path, { body: body  })
         # TODO: Is this the correct data to add to the log? May be too verbose.
-        Rails.logger.info("Google Analytics POST: #{response.request.uri} "\
+        Rails.logger.debug("Google Analytics POST: #{response.request.uri} "\
           "#{response.request.raw_body}")
-        Rails.logger.info("Google Analytics RESPONSE CODE: #{response.code}")
+        Rails.logger.debug("Google Analytics RESPONSE CODE: #{response.code}")
       rescue Exception => e
-        Rails.logger.error("Google Analytics POST attempt failed with the "\
+        Rails.logger.debug("Google Analytics POST attempt failed with the "\
           "following message: #{e.message}")
       end
     end


### PR DESCRIPTION
This adds Google Analytics tracking to the API.  It POSTs usage data to a Google Analytics endpoint.

**Use metrics**
Every API request that fetches an item or searches for items will POST two messages to Google Analytics.  One records a "pageview" and the other records any "events" associated with the request.  An "event" encapsulates data about the items returned to facilitate usage reporting to hubs.

**Exception handling**
Google Analytics tracking is meant to fail silently, so it will not interfere with the normal functioning of the API.

**Threads**
Google Analytics tracking runs in its own thread so it won't slow down API response time.  I have tested this locally with strategic use of `sleep` statements (see the two commits labeled "test thread").  _Is there more rigorous testing we can/should do here?_  Also, I've never used threading in a Rails app before, so please let me know if there's anything I may be overlooking.

**Logging**
The logging is currently very verbose to help with testing/debugging, but if this is going to be annoying we can pare it down.

**Testing/deployment**
To deploy this, use the following branches of `aws` and `automation`:
* https://github.com/dpla/aws/tree/api-google-analytics
* https://github.com/dpla/automation/tree/api-google-analytics

The google analytics dashboard can be found at analytics.google.com.  Select Digital Public Library of America > DPLA API TEST > All Web Site Data in the top left menu.  You can see data being logged in real time if you select the REAL-TIME > Overview or REAL-TIME > Events report from the left sidebar menu.

In the development environment, info is logged at `/srv/www/api/var/log/development.log `