### PR TITLE
Fix sort ordering

### DIFF
--- a/v1/lib/v1/searchable/sort.rb
+++ b/v1/lib/v1/searchable/sort.rb
@@ -64,7 +64,7 @@ module V1
             '_score' => {
               'order' => 'desc'
             },
-            '_id' => {
+            'id' => {
               'order' => 'asc'
             }
           }

--- a/v1/spec/lib/v1/searchable/sort_spec.rb
+++ b/v1/spec/lib/v1/searchable/sort_spec.rb
@@ -104,7 +104,7 @@ module V1
                  subject.build_sort_attributes(resource, params)
                  ).to eq({
                   '_score' => {'order' => 'desc'},
-                  '_id' => {'order' => 'asc'}
+                  'id' => {'order' => 'asc'}
                  })
         end
 


### PR DESCRIPTION
Fix sort ordering in Elasticsearch sort attributes that are generated by `V1::Searchable::Sort.build_sort_attributes`. The sort on `_id` does not seem to work; it's replaced by a sort on `id`, which does.

Fixes https://github.com/dpla/dpla-frontend/issues/562

The query that the API was issuing to Elasticsearch was coming back with a result like the following abridged example. Note the "sort" property for one of the hits.

```
{
    "took": 1892,
    "timed_out": false,
    "_shards": {
        "total": 5,
        "successful": 5,
        "failed": 0
    },
    "hits": {
        "total": 86729,
        "max_score": null,
        "hits": [
            {
            ...
            "sort": [
                12.957144,
                null
            ]
        ]
    }
}
```

That query was being issued with a "sort" property like the following:
```
	"sort": [
		{
			"_score": {
				"order":"desc"
			},
			"_id": {
				"order":"asc"
			}
		}
	]
```

When I changed `_id` to `id`, I started getting the following sort of "sort" data in the response:
```
"sort": [
                12.957144,
                "3eb161102aa5a43f9831623c6821b120"
            ]
```

The original Jira ticket, https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1921 , documents the method I've used to verify the results. See the file attached to that ticket with sample queries and `jq` commands.
