### PR TITLE
Add page number limit

### DIFF
--- a/v1/lib/v1/searchable.rb
+++ b/v1/lib/v1/searchable.rb
@@ -18,6 +18,9 @@ module V1
 
     # Default max page size
     MAX_PAGE_SIZE = 500
+
+    # Maximum page number
+    MAX_PAGE_NUM = 100
     
     # General query params that are not resource-specific
     BASE_QUERY_PARAMS = %w( q controller action sort_by sort_by_pin sort_order
@@ -84,6 +87,9 @@ module V1
 
     def search_offset(params)
       page = params["page"].to_i
+      if page > MAX_PAGE_NUM
+        raise BadRequestSearchError, "Page value #{page} is too high"
+      end
       page == 0 ? 0 : search_page_size(params) * (page - 1)
     end
 


### PR DESCRIPTION
Add page number limit in `V1::Searchable`.

High page numbers cause deep paging problems in Elasticsearch.