### PR TITLE
Change field boosts for ES 6

### DIFF
--- a/v1/config/dpla.yml.example
+++ b/v1/config/dpla.yml.example
@@ -64,8 +64,28 @@ caching:
 
 field_boosts:
   item:
+    # boosted
     sourceResource.title: 2
     sourceResource.description: 0.75
+    # not boosted: must be here to be included in the fields that are searched
+    sourceResource.subject: 1
+    sourceResource.collection.title: 1
+    sourceResource.collection.description: 1
+    sourceResource.contributor: 1
+    sourceResource.creator: 1
+    sourceResource.extent: 1
+    sourceResource.format: 1
+    sourceResource.genre: 1
+    sourceResource.language.name: 1
+    sourceResource.publisher: 1
+    sourceResource.relation: 1
+    sourceResource.spatial.name: 1
+    sourceResource.specType: 1
+    sourceResource.subject.name: 1
+    sourceResource.type: 1
+    dataProvider: 1
+    intermediateProvider: 1
+    provider.name: 1
   collection:
     title: 1
 

--- a/v1/lib/v1/searchable/query.rb
+++ b/v1/lib/v1/searchable/query.rb
@@ -96,7 +96,7 @@ module V1
           next if name =~ /^.+\.(before|after)$/
 
           if name == 'q'
-            fields = field_boost_for_all(resource) + ['_all']
+            fields = field_boost_for_all(resource)
             # The `q' parameter always wants a tokenized search, so we won't
             # ask for it to be quoted below in our call to
             # `.protect_metacharacters'.

--- a/v1/spec/lib/v1/searchable/query_spec.rb
+++ b/v1/spec/lib/v1/searchable/query_spec.rb
@@ -42,7 +42,7 @@ module V1
       describe "#string_queries" do
         it "returns correct query string for a free text search" do
           params = {'q' => 'something'}
-          attrs = subject.default_attributes.merge( {'fields'=>['_all']} )
+          attrs = subject.default_attributes.merge( {'fields'=>[]} )
           # e.g.:
           # [
           #   [
@@ -50,7 +50,7 @@ module V1
           #     {
           #       "default_operator"=>"AND",
           #       "lenient"=>true,
-          #       "fields"=>["_all"]
+          #       "fields"=>[]
           #     }
           #   ]
           # ]


### PR DESCRIPTION
Do away with the `_all` meta-field in the `fields` property of our Elasticsearch query. This was taken out of Elasticsearch 6.

We now have to put all of the fields we want to search during a `q` search in the `field_boosts` property of the `dpla.yml` config file.

The "not boosted" fields below are equivalent to what we've had all along before Elasticsearch 6. They were included with the `_all` meta-field at a level of 1. Now could be an opportunity to fine-tune them if anyone thinks they don't look right. I'm including Gretchen as a reviewer for this reason.

See https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-2194

Reviewers: I'll put up a demo and notify you so you can try some searches.